### PR TITLE
#7 Update .NET SDK TargetFramework from .net6.0 to .net7.0.

### DIFF
--- a/api-for-mongodb/01-create-mongodb-objects/csharp/app.csproj
+++ b/api-for-mongodb/01-create-mongodb-objects/csharp/app.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="33.1.1" />


### PR DESCRIPTION
Update .NET SDK TargetFramework from .net6.0 to .net7.0. This is the only available SDK version for sandbox at the moment. Consider using .net8.0 (LTS version) as it becomes available for sandbox users in Microsoft Learn training exercises.